### PR TITLE
DATAGO-70026 | Fix for PenTest issues and files copied to S3 bucket as part of release

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,7 +63,10 @@ jobs:
         sed -i "s@SolaceStackRegionNAME@${AWS_DEFAULT_REGION}@g" ci/solace-aws-ha-3az-prod-test.json
         sed -i "s@SolaceBucketRegionNAME@${BUCKETREGION}@g" ci/solace-aws-ha-3az-prod-test.json
         sed -i "s@SolaceBranchNAME@${{ env.BRANCH_NAME }}@g" ci/solace-aws-ha-3az-prod-test.json
-        aws s3 sync . s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync images s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync scripts s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync submodules s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync templates s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
 
     - name: Test with production deployment option (create public subnet)
       run: |

--- a/.github/workflows/build-vpc-test.yml
+++ b/.github/workflows/build-vpc-test.yml
@@ -66,7 +66,10 @@ jobs:
         sed -i "s@SolaceBucketRegionNAME@${BUCKETREGION}@g" ci/solace-aws-private-vpc-test.json
         sed -i "s@SolaceBranchNAME@${{ env.BRANCH_NAME }}@g" ci/solace-aws-ha-3az-private-vpc-prod-test.json
         sed -i "s@SolaceBranchNAME@${{ env.BRANCH_NAME }}@g" ci/solace-aws-private-vpc-test.json
-        aws s3 sync . s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync images s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync scripts s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync submodules s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
+        aws s3 sync templates s3://${{ env.TEST_S3_BUCKET }}/solace/eventbroker/${{ env.BRANCH_NAME }} --acl public-read
 
     - name: Test with production deployment option (create public subnet)
       run: |


### PR DESCRIPTION
## What is the purpose of this change?

Release pipeline for AWS QS copies unnecessary files to public S3 bucket which  

## How is this accomplished?

Copy only relevant files 